### PR TITLE
Add delayed extra package of dask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 scikit-learn>=0.21
 scipy>=1.0
 numba>=0.43
-dask>=1.2
+dask[delayed]>=1.2
 hdbscan>=0.8.10
 umap-learn>=0.3.8


### PR DESCRIPTION
I'm getting AttributeError: 'dask' has no attribute 'delayed'. I guess that's because
`pip install dask` only installs the core dask packages which do not include the delayed API. `pip install dask[delayed]` fixed it.